### PR TITLE
Chore ENV-2518: Dependabot Ignore Patch Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -16,7 +16,7 @@ test('extracts specific veloctl version', async () => {
   const veloctl = await download(version)
   expect(fs.existsSync(veloctl))
 
-  const versionOutput = cp.execFileSync(veloctl, ['-v']).toString()
+  const versionOutput = cp.execFileSync(veloctl, ['version']).toString()
   expect(versionOutput === `veloctl version ${version}`)
 })
 
@@ -26,6 +26,6 @@ test('extracts the latest veloctl', async () => {
   const veloctl = await download()
   expect(fs.existsSync(veloctl))
 
-  const versionOutput = cp.execFileSync(veloctl, ['-v']).toString()
+  const versionOutput = cp.execFileSync(veloctl, ['version']).toString()
   expect(versionOutput === `veloctl version ${latestVersion}`)
 })


### PR DESCRIPTION
This PR Addresses Chore ENV-2518: Dependabot Ignore Patch Updates:
* chore: ignore patch updates
